### PR TITLE
[#11] navbar/homepage-styling-fixes

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -345,6 +345,12 @@ a:hover{
         justify-content: center;
         min-height: 65vh !important;
     }
+
+    .home-heading-container{
+        display: flex;
+        justify-content: space-around;
+    }
+    
 }
 
 @media screen and (min-width:576px) and (max-width:724px){
@@ -373,10 +379,28 @@ a:hover{
     display: flex;
     flex-direction: column;
     align-items: center;
-    margin-bottom: 20px;
-    
-
     font-size: 1.5rem;
     font-weight: 700;
     margin-bottom: 20px;
+}
+.top-heading > .ant-row{
+    text-align: center;
+}
+
+@media screen and (max-width:420px){
+    .top-heading{
+        display: block;
+        text-align: center;
+    }
+
+    .top-heading > .ant-row{
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
+
+    .ant-row > .ant-col-8{
+        max-width: 100%;
+    }
+
 }

--- a/src/App.css
+++ b/src/App.css
@@ -76,24 +76,6 @@ a:hover{
     align-items: center;
 }
 
-@media screen and (max-width:1300px){
-    .main{
-        margin-left: 50px;
-    }
-}
-
-@media screen and (max-width:1170px){
-    .main{
-        margin-left: 50px;
-    }
-}
-
-@media screen and (max-width:1000px){
-    .main{
-        margin-left: 100px;
-    }
-}
-
 @media screen and (max-width:800px){
     .app{
         flex-direction: column;
@@ -102,13 +84,6 @@ a:hover{
 
     .navbar{
         flex: 1;
-    }
-
-    .main{
-        flex: 1;
-        margin-top: 90px;
-        margin-left: 0px;
-        margin-right: 10px;
     }
 
     .nav-container{
@@ -124,7 +99,7 @@ a:hover{
     }
 
     .ant-menu{
-        position: absolute;
+        position: relative;
         right: 0px;
     }
     .home-title{
@@ -345,6 +320,11 @@ a:hover{
     align-items: center;
     margin-top: 40px;
 }
+@media screen and (max-width:867px){
+    .home-heading-container {
+        flex-direction: column;
+    }
+}
 .show-more{
     margin-top: 0px !important;
 }
@@ -358,8 +338,26 @@ a:hover{
 .crypto-card-container{
     min-height: 65vh !important;
 }
+
+@media screen and (min-width:992px) and (max-width:1224px){
+    .crypto-card-container {
+        display: flex;
+        justify-content: center;
+        min-height: 65vh !important;
+    }
+}
+
+@media screen and (min-width:576px) and (max-width:724px){
+    .crypto-card-container {
+        display: flex;
+        justify-content: center;
+        min-height: 65vh !important;
+    }
+}
+
 .crypto-card{
     min-width: 250px;
+    float: left;
 }
 .crypto-card .crypto-image{
     width:35px;

--- a/src/components/Homepage.jsx
+++ b/src/components/Homepage.jsx
@@ -46,9 +46,10 @@ const Homepage = () => {
       <div className="home-heading-container">
         <Title level={2} className="home-title">Latest Crypto News</Title>
         <Title level={3} className="show-more">
-          {/* <Link to="/news">Show More</Link> */}
-          <Button type="default" size="large" href="/news">Show More</Button>
-          </Title>
+          <Button type="default" size="large">
+            <Link to="/News">Show More</Link>
+          </Button>
+        </Title>
       </div>
       <News simplified/> {/* simplified is a prop that we pass to the News component  */}
       

--- a/src/components/Homepage.jsx
+++ b/src/components/Homepage.jsx
@@ -37,9 +37,10 @@ const Homepage = () => {
       <div className="home-heading-container">
         <Title level={2} className="home-title">Top 10 Cryptocurrencies in the world</Title>
         <Title level={3} className="show-more">
-          {/* <Link to="/cryptocurrencies">Show More</Link> */}
-          <Button type="default" size="large" href="/cryptocurrencies">Show More</Button>
-          </Title>
+          <Button type="default" size="large">
+            <Link to="/Cryptocurrencies">Show More</Link>
+          </Button>
+        </Title>
       </div>
       <Cryptocurrencies simplified/>
       <div className="home-heading-container">

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -19,12 +19,12 @@ import {
 } from '@ant-design/icons';
 import {Row,Col, Image,Layout, Menu, Space, theme, Typography ,Avatar} from 'antd';
 import { Route, Routes, useNavigate } from 'react-router';
+import { Link } from 'react-router-dom';
 import Homepage from './Homepage';
 import Exchanges from './Exchanges';
 import Cryptocurrencies from './Cryptocurrencies';
 import CryptoDetailes from './CryptoDetailes';
 import News from './News';
-import Link from 'antd/es/typography/Link';
 import icon from '../images/cryptocurrency.png';
 import './nav.css'
 
@@ -48,7 +48,7 @@ const Navbar = () => {
               <Image src={icon} preview={false} />
             </Col>
             <Col>
-              <Typography.Title level={3} >
+              <Typography.Title level={5} >
                   <Link to="/">Coinverse</Link>
               </Typography.Title>
             </Col>
@@ -57,7 +57,8 @@ const Navbar = () => {
         <Menu
           theme="dark" 
           mode="inline" 
-          defaultSelectedKeys={['/' + window.location.href.split('/')[3]]}
+          defaultSelectedKeys={'/'}
+          selectedKeys={['/' + window.location.href.split('/')[3]]}
           items={[
             {
               key: '/',


### PR DESCRIPTION
Changed the styling based on screen width for crypto-card-container

Corrected the sidebar buttons location when minimized at a certain screen width so they are not cut-off. Also changed 'Coinverse' to H5 so that when minimized it was not word-wrapped.

Show more button was redirecting using a non-capitalized letter so the nav bar didn't properly show that the page was active, so I switched it.