### PR TITLE
[#74][#80] sticky nav/header & blur-effect for cards

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -840,30 +840,55 @@ transform: scale(1.2);
     border: 2px solid #fff;
     border-radius: 28px;
     box-shadow:3px 3px 6px 1px rgba( 31, 38, 135, 0.2 );
-    backdrop-filter: blur( 9.7px );
-    -webkit-backdrop-filter: blur( 9.7px );
+    
     transition: transform 0.3s;
+    display: grid;
+    grid-template-columns: [col1] 20% [col2] 20% [col3] 20% [col4] 20% [col5] 20% [end];
+    grid-template-rows: [row1] 25% [row2] 25% [row3] 25% [row4] 25% [last-line];
   }
   .ag-courses_item:hover{
     transform: scale(1.1);
   }
+
   .ag-courses-item_link {
-    display: block;
+    display: grid;
+    grid-row-start: 1;
+    grid-row-end: 5;
+    grid-column-start: 1;
+    grid-column-end: 6;
+    background: transparent;
+  }
+
+  .ag-courses-item_bg-container {
     padding: 30px 20px;
     background-color: var(--stats-card-bg-color);
     overflow: hidden;
+    backdrop-filter: blur( 9.7px );
+    -webkit-backdrop-filter: blur( 9.7px );
+    display: grid;
+    grid-row-start: 1;
+    grid-row-end: 5;
+    grid-column-start: 1;
+    grid-column-end: 6;
   }
   .ag-courses-item_link:hover .ag-courses-item_bg {
     -webkit-transform: scale(10);
     -ms-transform: scale(10);
     transform: scale(10);
   }
+
   .ag-courses-item_title {
+    padding: 30px 20px;
     min-height: 5px;
     overflow: hidden;
     color: #FFF ;
-    z-index: 2;
+    z-index: 3;
     position: relative;
+    display: grid;
+    grid-row-start: 1;
+    grid-row-end: 5;
+    grid-column-start: 1;
+    grid-column-end: 6;
   }
   .ag-courses-item_bg {
     height: 128px;

--- a/src/App.css
+++ b/src/App.css
@@ -58,9 +58,14 @@ a:hover{
     background-color: rgb(0, 21, 41);
 }
 
+.site-layout {
+    background-color: var(--back-color);
+}
+
 .main{
-    flex: 0.8;
-    
+    position: relative;
+    margin-top: 63px;
+    transition: all 0.2s;
 }
 .routes{
     padding: 20px;
@@ -144,10 +149,6 @@ h4{
         display: block !important;
     }
 
-    .ant-menu{
-        position: relative;
-        right: 0px;
-    }
     .home-title{
         font-size: 1.4rem !important;
     }
@@ -796,6 +797,10 @@ position: relative;
 
 .ant-menu-submenu-popup > ul.ant-menu-sub {
 min-width: 220px !important;
+}
+
+.ant-menu-submenu-popup {
+    position: fixed !important;
 }
 
 .icon-logo{

--- a/src/components/Cryptocurrencies.jsx
+++ b/src/components/Cryptocurrencies.jsx
@@ -72,7 +72,7 @@ const Cryptocurrencies = ({simplified, onClick, update}) => {
                       hoverable
                       >
                       <p>Price: {millify(currency.price)}</p>
-                      <p>Price: {millify(currency.marketCap)}</p>
+                      <p>Market Cap: {millify(currency.marketCap)}</p>
                       <p>Daily Change: &nbsp;
                       {millify(currency.change) < 0 ? (
                         <span style={{color: 'red'}}>{millify(currency.change)}% </span>

--- a/src/components/Homepage.jsx
+++ b/src/components/Homepage.jsx
@@ -30,9 +30,11 @@ const Homepage = ({onClick, update}) => {
             <div class="ag-courses_box">
               <div class="ag-courses_item">
                 <a href="#" class="ag-courses-item_link">
-                  <div class="ag-courses-item_bg"></div>
                   <div class="ag-courses-item_title">
-                  <Statistic title="Total Crypto Currencies" value={globalStats.total}/>
+                    <Statistic title="Total Crypto Currencies" value={globalStats.total}/>
+                  </div>
+                  <div class="ag-courses-item_bg-container">
+                    <div class="ag-courses-item_bg"></div>
                   </div>
                 </a>
               </div>
@@ -44,9 +46,11 @@ const Homepage = ({onClick, update}) => {
             <div class="ag-courses_box">
               <div class="ag-courses_item">
                 <a href="#" class="ag-courses-item_link">
-                  <div class="ag-courses-item_bg"></div>
                   <div class="ag-courses-item_title">
-                  <Statistic title="Total Exchanges" value={millify(globalStats.totalExchanges)}/>
+                    <Statistic title="Total Exchanges" value={millify(globalStats.totalExchanges)}/>
+                  </div>
+                  <div class="ag-courses-item_bg-container">
+                    <div class="ag-courses-item_bg"></div>
                   </div>
                 </a>
               </div>
@@ -58,9 +62,11 @@ const Homepage = ({onClick, update}) => {
             <div class="ag-courses_box">
               <div class="ag-courses_item">
                 <a href="#" class="ag-courses-item_link">
-                  <div class="ag-courses-item_bg"></div>
                   <div class="ag-courses-item_title">
-                  <Statistic title="Total Market Cap" value={millify(globalStats.totalMarketCap)}/>
+                    <Statistic title="Total Market Cap" value={millify(globalStats.totalMarketCap)}/>
+                  </div>
+                  <div class="ag-courses-item_bg-container">
+                    <div class="ag-courses-item_bg"></div>
                   </div>
                 </a>
               </div>
@@ -72,9 +78,11 @@ const Homepage = ({onClick, update}) => {
             <div class="ag-courses_box">
               <div class="ag-courses_item">
                 <a href="#" class="ag-courses-item_link">
-                  <div class="ag-courses-item_bg"></div>
                   <div class="ag-courses-item_title">
-                  <Statistic title="Total 24h Volume" value={millify(globalStats.total24hVolume)}/>
+                    <Statistic title="Total 24h Volume" value={millify(globalStats.total24hVolume)}/>
+                  </div>
+                  <div class="ag-courses-item_bg-container">
+                    <div class="ag-courses-item_bg"></div>
                   </div>
                 </a>
               </div>
@@ -86,9 +94,11 @@ const Homepage = ({onClick, update}) => {
             <div class="ag-courses_box">
               <div class="ag-courses_item">
                 <a href="#" class="ag-courses-item_link">
-                  <div class="ag-courses-item_bg"></div>
                   <div class="ag-courses-item_title">
-                  <Statistic title="Total Markets" value={millify(globalStats.totalMarkets)}/>
+                    <Statistic title="Total Markets" value={millify(globalStats.totalMarkets)}/>
+                  </div>
+                  <div class="ag-courses-item_bg-container">
+                    <div class="ag-courses-item_bg"></div>
                   </div>
                 </a>
               </div>

--- a/src/components/LineChart.jsx
+++ b/src/components/LineChart.jsx
@@ -106,8 +106,9 @@ const LineChart = ({ coinHistory, currentPrice, coinName }) => {
           <Title level={5} className="current-price">Current {coinName} Price: $ {currentPrice}</Title>
         </Col>
       </Row>
-      <Line data={data} options={options} className="graph"/>
-
+      <div className="graph">
+        <Line data={data} options={options}/>
+      </div>
     </>
   );
 };

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -62,47 +62,49 @@ const Navbar = () => {
   return (
     <>
        <Layout className='main_component' >
-        <Sider className='sidebar' trigger={null} collapsible collapsed={collapsed}>
-       <div className="logo" > 
-          <Row style={{width:"100%"}} type="flex" align="center">
-            <Col> 
-              <Image className='icon-logo' src={iconM} preview={false} />
-            </Col>
-            <Col>
-              <Typography.Title level={5} >
-                  <Link to="/" onClick={handleClick}>Coinverse</Link>
-              </Typography.Title>
-            </Col>
-          </Row>
-        </div>
-        <Menu
-          theme="dark" 
-          mode="inline" 
-          defaultSelectedKeys={'/'}
-          selectedKeys={[selectedMenuItem]}
-          onClick={handleClick}
-          items={[
-            {
-              key: '/',
-              icon: <HomeOutlined />,
-              label: <Link to="/">Home</Link>,
-            },
-            {
-              key: '/Cryptocurrencies',
-              icon: <SlidersOutlined />,
-              label: <Link to="/Cryptocurrencies">Cryptocurrencies</Link>,
-            },
-            {
-              key: '/News',
-              icon: <BulbOutlined/>,
-              label: <Link to="/News">News</Link>,
-            },
-          ]}
-        />
+        <Sider className="sidebar" trigger={null} collapsible collapsed={collapsed}>
+          <div className="logo" > 
+              <Row style={{width:"100%"}} type="flex" align="center">
+                <Col> 
+                  <Image className='icon-logo' src={iconM} preview={false} />
+                </Col>
+                <Col>
+                  <Typography.Title level={5} >
+                      <Link to="/" onClick={handleClick}>Coinverse</Link>
+                  </Typography.Title>
+                </Col>
+              </Row>
+            </div>
+          <Menu
+            theme="dark" 
+            mode="inline" 
+            defaultSelectedKeys={'/'}
+            selectedKeys={[selectedMenuItem]}
+            onClick={handleClick}
+            items={[
+              {
+                key: '/',
+                icon: <HomeOutlined />,
+                label: <Link to="/">Home</Link>,
+              },
+              {
+                key: '/Cryptocurrencies',
+                icon: <SlidersOutlined />,
+                label: <Link to="/Cryptocurrencies">Cryptocurrencies</Link>,
+              },
+              {
+                key: '/News',
+                icon: <BulbOutlined/>,
+                label: <Link to="/News">News</Link>,
+              },
+            ]}
+          />
           <Bookmarks sendCoins={sendCoins} handleClick={handleClick}/>
       </Sider>
       <Layout className="site-layout">
-      <Header style={{ paddingLeft: "1rem",fontSize:"1.8rem"}} className='nav-head'>
+      <Header style={{ paddingLeft: "1rem", fontSize: "1.8rem",
+        maxWidth: collapsed ? "calc(100% - 80px)" : "calc(100% - 200px)",
+        transform: collapsed ? `translateX(80px)` : `translateX(200px)`}} className='nav-head'>
           {React.createElement(collapsed ? MenuUnfoldOutlined : MenuFoldOutlined, {
             className: 'trigger',
             onClick: () => setCollapsed(!collapsed),
@@ -111,7 +113,8 @@ const Navbar = () => {
           <ToggleMode/>
         </Header>
         <Content>
-        <div className="main" >
+        <div className="main" style={{ transform: collapsed ? `translateX(80px)` : `translateX(200px)`,
+          maxWidth: collapsed ? "calc(100% - 80px)" : "calc(100% - 200px)"}}>
             <Layout>
                 <div className='routes'>
                 <Routes>

--- a/src/components/News.jsx
+++ b/src/components/News.jsx
@@ -41,7 +41,7 @@ const News = ({simplified}) => {
                   <Card
                     title={
                       <div className="news-image-container"  >
-                      <Title className="news-title" level={4}>{news.name.length>75?news.name.substr(0,75)+" ...":news.name}</Title>
+                      <Title className="news-title" level={4}>{news.name.length>75?news.name.substr(0,75)+"...":news.name}</Title>
                       <img style={{maxWidth: '200px' , maxHeight: '100px'}} src={news?.image?.thumbnail?.contentUrl || demoImage} alt="news"/>
                     </div>
                     }

--- a/src/components/nav.css
+++ b/src/components/nav.css
@@ -6,12 +6,32 @@
     height: 100vh;
 }
 
+.sidebar {
+  position: fixed !important;
+  height: 100%;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1050;
+}
+
+.main_component {
+  position: relative;
+  z-index: 0;
+  background-color: --back-color;
+}
+
 .nav-head{
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    background-color: var(--nav-color) !important;
-    transition: 0.5s;
+  transition: all 0.2s;
+  position: fixed;
+  top: 0;
+  right: 0;
+  left: 0;
+  z-index: 999;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background-color: var(--nav-color) !important;
 }
 
 .contentt{


### PR DESCRIPTION
Sticky navbar/header

Blur effect fix for text in 'Global Crypto Stats'

Also included a fix for blurry text with the LineChart. This was a simple change of surrounding the chart in a div and putting the 'graph' class on to the parent div rather than the chart itself (specifically the padding causes this issue).

![image](https://user-images.githubusercontent.com/89403905/223652337-9de24210-1d2a-4775-b660-e5008898a881.png)

![image](https://user-images.githubusercontent.com/89403905/223652621-df84c86d-61af-4c3f-8562-877037134655.png)
![image](https://user-images.githubusercontent.com/89403905/223652646-e89caa75-665e-4f3e-af93-bdfa1c7bafc0.png)

